### PR TITLE
new header for dockerfile. replaces deprecated MAINTAINER instruction

### DIFF
--- a/Dockerfile-app
+++ b/Dockerfile-app
@@ -1,5 +1,9 @@
 FROM alpine:3.7
-MAINTAINER James Lamb <jaylamb20@gmail.com>
+LABEL maintainer="jaylamb20@gmail.com"
+LABEL author1="brad.beechler@uptake.com"
+LABEL author2="jaylamb20@gmail.com"
+LABEL website="https://github.com/uptake/groundhog"
+LABEL description="groundhog is a service which provides access to SRTM elevation data."
 
 ####################
 # SETUP            #


### PR DESCRIPTION
The `MAINTAINER` instruction has been deprecated by docker ([link](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated)).  This replaces the `MAINTAINER` instruction with the recommended `LABEL` instruction in addition to adding labels for: 
* authors
* website
* one sentence description