### PR TITLE
[ci] add Dockerfile linting (fixes #33)

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,13 +1,13 @@
 name: linting
 
-# only run this workflow on new commits to master
-on:
-  push:
-    branches:
-    - master
-  pull_request:
-    branches:
-    - master
+# # only run this workflow on new commits to master
+# on:
+#   push:
+#     branches:
+#     - master
+#   pull_request:
+#     branches:
+#     - master
 
 jobs:
   test:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,29 @@
+name: linting
+
+# only run this workflow on new commits to master
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    name: ${{ matrix.task }}
+    runs-on: macos-latet
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - task: lint-dockerfile
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v1
+      - name: lint dockerfile
+        shell: bash
+        run: |
+          brew upgrade
+          brew install hadolint
+          hadolint Dockerfile

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,13 +1,13 @@
 name: linting
 
-# # only run this workflow on new commits to master
-# on:
-#   push:
-#     branches:
-#     - master
-#   pull_request:
-#     branches:
-#     - master
+# only run this workflow on new commits to master
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   test:


### PR DESCRIPTION
I'm trying to learn [`hadolint`](https://github.com/hadolint/hadolint), a linter for Dockerfiles, this week. This PR introduces a continuous integration job on GitHub Actions that uses that linter on this project's `Dockerfile`.